### PR TITLE
michalmagic42/response-group-fix

### DIFF
--- a/src/AmazonInventoryList.php
+++ b/src/AmazonInventoryList.php
@@ -226,8 +226,7 @@ class AmazonInventoryList extends AmazonInventoryCore implements \Iterator
     {
         if ($this->tokenFlag && $this->tokenUseFlag) {
             $this->options['Action'] = 'ListInventorySupplyByNextToken';
-            unset($this->options['QueryStartDateTime']);
-            unset($this->options['ResponseGroup']);
+            unset($this->options['QueryStartDateTime']);;
             $this->resetSkus();
         } else {
             $this->options['Action'] = 'ListInventorySupply';


### PR DESCRIPTION
Inventory details - ResponseGroup Fix

Problem: Correct `ResponseGroup` value is available only for the first batch
         of data downloaded as InventorySupplies.
         The same SupplyDetail are missed from the data.       

+ Remove the line `unset($this->options['ResponseGroup']);`
  from `prepareToken()` method as the option was unset globally
+ The same all SupplyDetail are available for all batches
